### PR TITLE
fixed: README referenced the wrong service name `inline-messenger` vs `inline-messaging`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This package has example usage of the [inline messenger](https://github.com/mdgr
 After installing this package, hit `cmd-alt-+`.  A new page will be created with some example messages and a code suggestion.
 Use `alt-up` or `alt-down` to scroll through the messages, and `cmd-shift-a` to accept the suggestion.
 
-Inline messenger provides a service for use in other Atom projects. With it, a package can show messages next to the relevant, highlighted code,  and optionally make a code suggestion for the selected text. To use it, include `inline-messenger` in the `consumedServices` section of your `package.json`:
+Inline messenger provides a service for use in other Atom projects. With it, a package can show messages next to the relevant, highlighted code,  and optionally make a code suggestion for the selected text. To use it, include `inline-messaging` in the `consumedServices` section of your `package.json`:
 
 ```json
 {
   "name": "my-package",
   "consumedServices": {
-    "inline-messenger": {
+    "inline-messaging": {
       "versions": {
         "^1.0.0": "consumeInlineMessenger"
       }


### PR DESCRIPTION
I copied the example code from README and was scratching my head for a little bit over this one xD
